### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ tests:
 	vendor/bin/tester -s -p php --colors 1 -C tests
 
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 dev:
 	NETTE_DEBUG=1 NETTE_ENV=dev php -S 0.0.0.0:8000 -t www


### PR DESCRIPTION
## Summary

Replace `phpdbg` with `php` in the `coverage` Makefile target so this repository matches the org-wide coverage migration tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps the skeleton aligned with the new `php`-based coverage command.

## Changes

- switch the `coverage` target in `Makefile` from `-p phpdbg` to `-p php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification (if applicable)
- `make coverage` currently fails locally because this environment does not have Xdebug, PCOV, or PHPDBG available for code coverage when running plain `php`.