### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"
       make: "init coverage"


### PR DESCRIPTION
## What changed

- Added `secrets: inherit` to `.github/workflows/coverage.yml` so the reusable coverage workflow receives repository secrets.

## Why

- Issue contributte/contributte#74 rolls this out across repositories, and this repo's coverage workflow caller needs inherited secrets for the reusable workflow to run with the expected credentials.